### PR TITLE
修改URL及请求头

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -4,12 +4,15 @@ addEventListener('fetch', event => {
   
   async function handleRequest(request) {
     const url = new URL(request.url);
-    const actualUrlStr = url.pathname.replace("/proxy/","")
+    const actualUrlStr = url.pathname.replace("/proxy/","") + url.search + url.hash
   
     const actualUrl = new URL(actualUrlStr)
   
     const modifiedRequest = new Request(actualUrl, {
-      headers: request.headers,
+      headers: {
+        ...request.headers,
+        'Host': actualUrl.hostname
+      },
       method: request.method,
       body: request.body,
       redirect: 'follow'


### PR DESCRIPTION
今天使用的时候发现url中的查询参数和哈希部分似乎被忽略了，比如代理`https://tool.gljlw.com/qq/?qq=1919810`时只会跳转默认qq号，参数`?qq=1919810`被忽略了，故在第9行添加了`+ url.search + url.hash`

此外还遇到过报错1003，`You've requested an IP address that is part of the Cloudflare network. A valid Host header must be supplied to reach the desired website.`，根据ChatGPT给出的代码修改后不再报错1003，且暂未遇到其它报错，可以再复核一下